### PR TITLE
Sections: remove url field that is not present in Todoist's API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed `url` field from `Section` model to simplify data structure
+
 ## [0.2.0] - 2025-08-16
 
 ### Added

--- a/src/models.rs
+++ b/src/models.rs
@@ -57,7 +57,6 @@ pub struct Section {
     pub name: String,
     pub project_id: String,
     pub order: i32,
-    pub url: String,
 }
 
 /// Todoist Comment model

--- a/tests/models_tests.rs
+++ b/tests/models_tests.rs
@@ -83,7 +83,6 @@ fn test_section_creation() {
         name: "Development".to_string(),
         project_id: "proj_123".to_string(),
         order: 1,
-        url: "https://todoist.com".to_string(),
     };
 
     assert_eq!(section.id, "section_123");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Simplified section data by removing the URL attribute. Responses and payloads will no longer include this field, affecting any consumers that read or write section URLs.

* Documentation
  * Updated changelog to clearly describe the data change and its impact on consumers.

* Tests
  * Updated tests to reflect the new section data shape and ensure continued reliability after the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->