### PR TITLE
fix get_tasks_by_filter url

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -359,7 +359,7 @@ impl TodoistWrapper {
             query_params.push(("cursor", cursor.clone()));
         }
 
-        self.make_get_request_paginated("/tasks", &query_params).await
+        self.make_get_request_paginated("/tasks/filter", &query_params).await
     }
 
     /// Create a new task


### PR DESCRIPTION
The get_tasks_by_filter fn needs to call the /tasks/filter endpoint. Hitting /tasks, even when a query value is provided in the querystr, causes todoist to return _all_ tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated task filtering to use a more optimized API endpoint, enhancing how the system retrieves and displays filtered task results for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->